### PR TITLE
fix(build): have `x64` macOS builds run on `x64` runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
                       arch: arm64
                     - os: ubuntu-latest
                       arch: armv7l
-                    - os: macos-latest
+                    - os: macos-15-intel
                       arch: x64
                     # - os: macos-latest # BUG: This one doesn't work.
                     #   arch: ia32


### PR DESCRIPTION
The zlib library seems to not install properly in the x64 macOS runnner. It uses `arm64` architecture.

https://github.com/actions/runner-images#available-images

`macos-latest` points towards an `arm` image. This PR changes the `x64` build to run on an `x64` runner.

---

https://github.com/8Crafter-Studios/Bedrock-World-Editor/actions/runs/28343692786/job/83963773767#step:1:15

```
Runner Image
  Image: macos-15-arm64
  Version: 20260623.0190.1
  Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260623.0190/images/macos/macos-15-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260623.0190
```

```
[leveldb] platform details: darwin-24-arm64 (with architecture override: x64)
Error: dlopen(/Users/runner/work/Bedrock-World-Editor/Bedrock-World-Editor/node_modules/@8crafter/leveldb-zlib/build/Release/node-leveldb.node, 0x0001): tried: '/Users/runner/work/Bedrock-World-Editor/Bedrock-World-Editor/node_modules/@8crafter/leveldb-zlib/build/Release/node-leveldb.node' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/Bedrock-World-Editor/Bedrock-World-Editor/node_modules/@8crafter/leveldb-zlib/build/Release/node-leveldb.node' (no such file), '/Users/runner/work/Bedrock-World-Editor/Bedrock-World-Editor/node_modules/@8crafter/leveldb-zlib/build/Release/node-leveldb.node' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
```